### PR TITLE
Update README: python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Primero se deben correr los siguientes comandos para instalar Ansible:
 
 ```bash
 ## Instalamos la version de Python a utilizar
-pyenv install 3.9.9
+pyenv install 3.11.11
+
+## Fijamos la version de Python a utilizar
+pyenv local 3.11.11
 
 ## Creamos el entorno de Python con direnv
 direnv allow


### PR DESCRIPTION
En el siguiente bloque, al ejecutar `direnv allow`, el entorno de Python no podía crearse porque **no estaba definida la versión de Python a utilizar**.

Para resolverlo, existen dos alternativas:

* `pyenv local {version}` → establece la versión solo para este proyecto
* `pyenv global {version}` → establece la versión para todo el sistema del usuario

En este caso se optó por configurar la versión **localmente**.

```bash
## Instalamos la versión de Python a utilizar
pyenv install 3.9.9

## Creamos el entorno de Python con direnv
direnv allow

## Instalamos Ansible en el entorno de Python
pip3 install -r requirements.txt
```

Además, se actualizó la versión mostrada a **3.11.11**, que es la definida en el archivo `.tool-versions` y compatible con la versión de Ansible especificada en el `requirements.txt`.

