### PR TITLE
chore: bump mikroways.workstation a 2.4.2

### DIFF
--- a/ansible/requirements/roles.yml
+++ b/ansible/requirements/roles.yml
@@ -1,2 +1,2 @@
 - name: mikroways.workstation
-  version: 2.4.0
+  version: 2.4.2


### PR DESCRIPTION
Actualiza el rol `mikroways.workstation` de 2.4.0 a 2.4.2, que agrega la instalación automática de `mw-skills` durante el setup de la estación de trabajo.