### PR TITLE
chore: bump mikroways.workstation a 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ trabajar inmediatamente luego de correrlo. Al momento, depende de dos roles:
 * **mikroways.tools:** role privado con un set de herramientas que usamos a
   diario y fueron exclusivamente desarrolladas por Mikroways. Es opcional.
 
-# Herramientas requeridas
+## Herramientas requeridas
 
 * [direnv](https://direnv.net/)
 * [python3](https://www.python.org/downloads/)
 * [pyenv](https://github.com/pyenv/pyenv#installation)
 
-# Instalar roles y requerimientos
+## Instalar roles y requerimientos
 
 Primero se deben correr los siguientes comandos para instalar Ansible:
 
@@ -55,7 +55,7 @@ ansible-galaxy role install -r ansible/requirements/roles.yml --force-with-deps
 ansible-galaxy role install -r ansible/requirements/roles-mw.yml --force-with-deps
 ```
 
-# Ejecutar playbook en local
+## Ejecutar playbook en local
 
 Antes de continuar, es recomendable realizar resguardos de toda configuración del
 usuario donde se ejecute el playbook o realizarlo en un usuario nuevo.
@@ -73,7 +73,7 @@ Si perteneces a Mikroways, entonces deberías además correr el siguiente playbo
 ansible-playbook ansible/playbooks/vm-setup-mw.yml -i ansible/inventory/localhost.yml -K
 ```
 
-# Consideraciones
+## Consideraciones
 
 * Si se está utilizando Pop!\_Os se debe agregar además `-e ansible_distribution=Ubuntu`
 
@@ -83,7 +83,7 @@ ansible-playbook ansible/playbooks/vm-setup-mw.yml -i ansible/inventory/localhos
 * Si ya utilizabas dotfiles, considerá subir tus cambios porque podrías perder
   alguna de tus personalizaciones.
 
-# Funcionamiento
+## Funcionamiento
 
 El playbook sigue la siguiente serie de pasos:
 
@@ -98,12 +98,12 @@ El playbook sigue la siguiente serie de pasos:
 1. (opcional) Si se indico la instalación de las herramientas de Mikroways,
    entonces estas se instalaran en la carpeta `~/.mikroways/tools`.
 
-# Recomendaciones
+## Recomendaciones
 
 Una vez instalado tu desktop con este playbook, te recomendamos que agregues en
 `$HOME/.envrc` la siguiente configuración:
 
-```
+```bash
 use asdf
 ```
 
@@ -115,12 +115,12 @@ autocomplete, entonces proveemos el alias **`mw-fix-kube-completion`** que
 debería actualizar el autocomplete que se suele romper entre diferentes
 versiones de kubectl que se manejan con asdf.
 
-# Usar este playbook en un bastion
+## Usar este playbook en un bastion
 
 Si querés usar directamente este playbook en una vm determinada, proponemos usar
 el siguiente comando:
 
-```
+```bash
 ansible-playbook ansible/playbooks/vm-setup.yml [-K] \
   -i SOME_USER@10.10.10.10, \
   -e ansible_user=SOME_USER
@@ -130,7 +130,7 @@ ansible-playbook ansible/playbooks/vm-setup.yml [-K] \
 > especificado tanto en la opción `-i` como en `ansible_user`. Además, para usar
 > un inventario inline es **fundamental el uso de la coma al final de la IP**.
 
-# ¿Como probar el entorno en Vagrant?
+## ¿Como probar el entorno en Vagrant?
 
 Simplemente correr:
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ ansible-galaxy role install -r ansible/requirements/roles.yml
 ansible-galaxy role install -r ansible/requirements/roles-mw.yml
 ```
 
+> **Nota:** Ansible ignora el `ansible.cfg` del repositorio si el directorio tiene
+> permisos de escritura para todos (world-writable). Para evitar el warning y que
+> se cargue la configuración correctamente, correr una vez:
+> ```bash
+> chmod o-w .
+> ```
+
 Para actualizar los requerimientos:
 
 ```bash
@@ -49,10 +56,10 @@ Para actualizar los requerimientos:
 git pull
 
 ## Si no pertenece a Mikroways actualizamos roles con el siguiente comando:
-ansible-galaxy role install -r ansible/requirements/roles.yml --force-with-deps
+ansible-galaxy role install -r ansible/requirements/roles.yml --force-with-deps --force
 
 ## Si pertenece a Mikroways actualizamos roles con el siguiente comando:
-ansible-galaxy role install -r ansible/requirements/roles-mw.yml --force-with-deps
+ansible-galaxy role install -r ansible/requirements/roles-mw.yml --force-with-deps --force
 ```
 
 ## Ejecutar playbook en local
@@ -67,7 +74,7 @@ actualización debemos ejecutar el siguiente comando:
 ansible-playbook ansible/playbooks/vm-setup.yml -i ansible/inventory/localhost.yml -K
 ```
 
-Si perteneces a Mikroways, entonces deberías además correr el siguiente playbook
+Si perteneces a Mikroways, entonces deberías además correr el siguiente playbook:
 
 ```bash
 ansible-playbook ansible/playbooks/vm-setup-mw.yml -i ansible/inventory/localhost.yml -K
@@ -140,4 +147,11 @@ vagrant up
 
 ## Para ingresar y verificar el entorno
 vagrant ssh
+```
+
+Para probar también las herramientas privadas de Mikroways (`vm-setup-mw.yml`), una vez
+que la VM esté levantada:
+
+```bash
+vagrant provision --provision-with mw
 ```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ ansible-galaxy role install -r ansible/requirements/roles-mw.yml
 > **Nota:** Ansible ignora el `ansible.cfg` del repositorio si el directorio tiene
 > permisos de escritura para todos (world-writable). Para evitar el warning y que
 > se cargue la configuración correctamente, correr una vez:
+>
 > ```bash
 > chmod o-w .
 > ```
@@ -100,7 +101,7 @@ El playbook sigue la siguiente serie de pasos:
    wrapper para descargar binarios.
 1. Configura [asdf](https://asdf-vm.com/) y prepara una serie de plugins y
    versiones de productos.
-1. Crea las configuraciones propias del entorno dejandolas a disposicion en el
+1. Crea las configuraciones propias del entorno dejándolas a disposición en el
    directorio `~/.mikroways/dotfiles`.
 1. (opcional) Si se indico la instalación de las herramientas de Mikroways,
    entonces estas se instalaran en la carpeta `~/.mikroways/tools`.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
 
   # Para probar vm-setup-mw.yml (herramientas privadas de Mikroways):
   #   vagrant provision --provision-with mw
-  config.vm.provision :ansible, run: "never", name: "mw" do |ansible|
+  config.vm.provision "mw", type: :ansible, run: "never" do |ansible|
     ansible.galaxy_role_file = "ansible/requirements/roles-mw.yml"
     ansible.playbook = "ansible/playbooks/vm-setup-mw.yml"
     ansible.raw_ssh_args = ["-o ForwardAgent=yes"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,8 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/jammy64"
 
+  config.ssh.forward_agent = true
+
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "4096"
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,16 +5,28 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/jammy64"
 
   config.vm.provider "virtualbox" do |vb|
-     vb.memory = "4096"
+    vb.memory = "4096"
   end
-    config.vm.provision :ansible do |ansible|
-        ansible.galaxy_role_file = "ansible/requirements/roles.yml"
-        ansible.playbook = "ansible/playbooks/vm-setup.yml"
-        ansible.raw_ssh_args = ["-o ForwardAgent=yes"]
-        ansible.extra_vars = {
-          ansible_user: "vagrant",
-          ansible_python_interpreter: "/usr/bin/python3",
-          mw_tools_enabled: false
-        }
-    end
+
+  config.vm.provision :ansible do |ansible|
+    ansible.galaxy_role_file = "ansible/requirements/roles.yml"
+    ansible.playbook = "ansible/playbooks/vm-setup.yml"
+    ansible.raw_ssh_args = ["-o ForwardAgent=yes"]
+    ansible.extra_vars = {
+      ansible_user: "vagrant",
+      ansible_python_interpreter: "/usr/bin/python3",
+    }
+  end
+
+  # Para probar vm-setup-mw.yml (herramientas privadas de Mikroways):
+  #   vagrant provision --provision-with mw
+  config.vm.provision :ansible, run: "never", name: "mw" do |ansible|
+    ansible.galaxy_role_file = "ansible/requirements/roles-mw.yml"
+    ansible.playbook = "ansible/playbooks/vm-setup-mw.yml"
+    ansible.raw_ssh_args = ["-o ForwardAgent=yes"]
+    ansible.extra_vars = {
+      ansible_user: "vagrant",
+      ansible_python_interpreter: "/usr/bin/python3"
+    }
+  end
 end

--- a/ansible/inventory/bastion-inventory.yml
+++ b/ansible/inventory/bastion-inventory.yml
@@ -1,7 +1,7 @@
 ---
 all:
   vars:
-    ansible_user: "{{ lookup('env','USER')}}"
+    ansible_user: "{{ lookup('env','USER')}}"  # ajustar si el usuario remoto difiere del local
   hosts:
     bastion:
       ansible_host: bastion-example.mikroways.net
@@ -14,6 +14,5 @@ all:
       mw_user_environment_install_dotfiles: true
       mw_podman_enabled: false
       mw_docker_enabled: false
-      mw_tools_enabled: false
       mw_workstation_local_packages_only:
         - kubectl

--- a/ansible/inventory/bastion-inventory.yml
+++ b/ansible/inventory/bastion-inventory.yml
@@ -1,18 +1,93 @@
 ---
+# Inventario de ejemplo para bastiones remotos. Ajustar según las necesidades
+# del equipo que va a usar la máquina.
+#
+# Variables disponibles y valores por defecto:
+# https://github.com/Mikroways/ansible-workstation/tree/master/defaults/main
 all:
   vars:
-    ansible_user: "{{ lookup('env','USER')}}"  # ajustar si el usuario remoto difiere del local
+    # Ajustar si el usuario remoto difiere del local
+    ansible_user: "{{ lookup('env','USER')}}"
   hosts:
     bastion:
       ansible_host: bastion-example.mikroways.net
-      mw_user_environment_tools_enabled: false
-      mw_user_environment_dotfiles_git_write_local_config: false
-      mw_user_environment_language_managers_enabled: false
-      mw_user_environment_krew_plugins_enabled: false
-      mw_user_environment_tf_plugins_enabled: false
-      mw_user_environment_helm_plugins_enabled: false
-      mw_user_environment_install_dotfiles: true
-      mw_podman_enabled: false
-      mw_docker_enabled: false
-      mw_workstation_local_packages_only:
-        - kubectl
+
+      # Docker no suele necesitarse en un bastion
+      workstation_docker_enabled: false
+
+      # Los dotfiles configuran zsh, aliases y el entorno de shell.
+      # En un bastion se suelen desactivar para evitar problemas de
+      # compatibilidad o configuración no deseada.
+      workstation_dotfiles_enabled: false
+
+      # Herramientas binarias a instalar (navi, govc, amtool, promtool, certinfo,
+      # gitlab-runner, fzf, sonobuoy). Por defecto instala todas.
+      # Ver https://github.com/Mikroways/ansible-workstation/blob/main/defaults/main/tools.yml
+      # Para limitar a las necesarias:
+      # workstation_tools_only:
+      #   - navi
+      #   - fzf
+      # OJO: workstation_tools_only: [] instala TODAS (lista vacía = sin filtro).
+      # Para no instalar ninguna hay que vaciar la lista superior
+      workstation_tools: []
+
+      # Herramientas de asdf a instalar.
+      # Por defecto instala todo el stack completo 
+      # Ver https://github.com/Mikroways/ansible-workstation/blob/main/defaults/main/asdf.yml
+      #
+      # NOTA: se usa "latest" como ejemplo pero en entornos de producción se
+      # recomienda pinear versiones específicas para evitar cambios inesperados,
+      # por ejemplo: version: ["1.31.0"]
+      workstation_asdf_tools:
+        kubectl:
+          version: [latest]
+        helm:
+          version: [latest]
+        krew:
+          version: [latest]
+        terraform:
+          version: [latest]
+        terragrunt:
+          version: [latest]
+        tflint:
+          version: [latest]
+        sops:
+          version: [latest]
+        age:
+          version: [latest]
+        jq:
+          version: [latest]
+        yq:
+          version: [latest]
+        direnv:
+          version: [latest]
+        awscli:
+          version: [latest]
+        sshuttle:
+          version: [latest]
+        teleport-ent:
+          version: [latest]
+
+      # Plugins de krew (kubectl)
+      # Ver https://github.com/Mikroways/ansible-workstation/blob/main/defaults/main/krew-plugins.yml
+      workstation_krew_plugins:
+        - ctx
+        - ns
+        - oidc-login
+        - view-secret
+        - access-matrix
+
+      # Plugins de Helm
+      # Ver https://github.com/Mikroways/ansible-workstation/blob/main/defaults/main/helm-plugins.yml
+      workstation_helm_plugins:
+        - name: diff
+          repo: https://github.com/databus23/helm-diff
+        - name: secrets
+          repo: https://github.com/jkroepke/helm-secrets
+
+      # Proxy (si el bastion está detrás de un proxy corporativo)
+      # Ver https://github.com/Mikroways/ansible-workstation/blob/main/defaults/main/proxy.yml
+      # workstation_proxy_enabled: true
+      # workstation_proxy_http: http://proxy.example.com:3128
+      # workstation_proxy_https: http://proxy.example.com:3128
+      # workstation_proxy_no_proxy: localhost,127.0.0.1,.example.com

--- a/ansible/inventory/localhost.yml
+++ b/ansible/inventory/localhost.yml
@@ -1,9 +1,9 @@
 ---
 all:
   vars:
-    ansible_python_interpreter: /usr/bin/python3
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
     ansible_connection: local
     ansible_user: "{{ lookup('env','USER')}}"
-    mw_tools_enabled: false
+
   hosts:
     localhost:

--- a/ansible/inventory/localhost.yml
+++ b/ansible/inventory/localhost.yml
@@ -1,7 +1,7 @@
 ---
 all:
   vars:
-    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+    ansible_python_interpreter: /usr/bin/python3
     ansible_connection: local
     ansible_user: "{{ lookup('env','USER')}}"
 

--- a/ansible/playbooks/vm-setup-mw.yml
+++ b/ansible/playbooks/vm-setup-mw.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install a Mikroways desktop bastion
+- name: Install Mikroways private tools
   hosts: all
   gather_facts: true
   tasks:

--- a/ansible/playbooks/vm-setup.yml
+++ b/ansible/playbooks/vm-setup.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install a Mikroways desktop bastion
+- name: Install a Mikroways workstation
   hosts: all
   gather_facts: true
   tasks:

--- a/ansible/requirements/roles.yml
+++ b/ansible/requirements/roles.yml
@@ -1,2 +1,2 @@
 - name: mikroways.workstation
-  version: 2.5.0
+  version: 2.6.0

--- a/ansible/requirements/roles.yml
+++ b/ansible/requirements/roles.yml
@@ -1,2 +1,2 @@
 - name: mikroways.workstation
-  version: 2.4.2
+  version: 2.5.0


### PR DESCRIPTION
## Summary

Bump de \`mikroways.workstation\` de 2.4.2 → 2.5.0 → 2.6.0, junto con fixes y mejoras en vm-setup.

**Fixes en vm-setup:**
- Corregir nombre de los playbooks para que sean mas representativos.
- Actualizar bastion-inventory con las variables correctas del rol y documentación
- Eliminar variable \`mw_tools_enabled\` sin uso
- Corregir sintaxis de provision en Vagrantfile
- Habilitar SSH agent forwarding en \`vagrant ssh\`
- Agregar soporte para provisionar herramientas privadas de Mikroways en Vagrant
- Usar Python del sistema en lugar del venv para módulos Ansible en localhost (revierte cambio anterior que rompía \`apt_repository\` de geerlingguy.docker)

## Pruebas realizadas

- [x] Correr \`vagrant up\` + \`vagrant provision --provision-with mw\` en VM Ubuntu 22.04
- [x] Correr playbooks localmente en Pop OS 22.04 con \`-e ansible_distribution=Ubuntu\`